### PR TITLE
docs: add intersectRecursive info

### DIFF
--- a/src/guide/meshes/events.md
+++ b/src/guide/meshes/events.md
@@ -143,3 +143,13 @@ If using `Raycaster` component, you should set `intersect-mode` prop :
 ```html
 <Raycaster intersect-mode="frame" />
 ```
+
+## `intersectRecursive`
+
+If present (=`true`), it also checks all descendants. Otherwise it only checks intersection with the object.
+
+Default is `false`.
+
+```html
+<Raycaster intersect-recursive />
+```


### PR DESCRIPTION
Added missing paragraph describing `intersectRecursive` attribute for Raycaster component.