### PR TITLE
DOC: Fix VR button documentation path

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -177,7 +177,7 @@ module.exports = {
 					text: 'Extras',
 					children: [
 						{
-							link: '/extras/vrbutton/',
+							link: '/guide/extras/vrbutton',
 							text: 'VR-Button',
 						},
 					]


### PR DESCRIPTION
Small PR for the docs. The link to VR button documentation page is broken
![image](https://user-images.githubusercontent.com/10913199/135934720-0822f3d2-4786-4272-9697-4067c8139ca7.png)

updating the link in config.js fixed it. 
