### PR TITLE
Fixed a typo and link for RenderPass

### DIFF
--- a/src/guide/postprocessing/index.md
+++ b/src/guide/postprocessing/index.md
@@ -8,7 +8,7 @@ Passes :
 - `FilmPass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/FilmPass.ts))
 - `FXAAPass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/FXAAPass.ts))
 - `HalftonePass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/HalftonePass.ts))
-- `Renderpass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/Renderpass.ts))
+- `RenderPass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/RenderPass.ts))
 - `SMAAPass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/SMAAPass.ts))
 - `UnrealBloomPass` ([source](https://github.com/troisjs/trois/blob/master/src/effects/UnrealBloomPass.ts))
 


### PR DESCRIPTION
In Postprocessing page: Fixed a typo for "RenderPass" and also fixed the broken link.